### PR TITLE
build: update jasmine-web-test-runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "protractor": "^7.0.0",
     "tinyglobby": "^0.2.12",
     "typescript": "5.8.2",
-    "web-test-runner-jasmine": "0.1.0"
+    "web-test-runner-jasmine": "0.1.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   '@web/test-runner-chrome@0.18.0':
-    hash: sdcmdruhfajls5fgcrmywzbtte
+    hash: 9b04fa08ff126a3b83bd1a253f6f70e851f0414497a709fee0ac57f1aeb3f67d
     path: patches/@web__test-runner-chrome@0.18.0.patch
 
 importers:
@@ -60,8 +60,8 @@ importers:
         specifier: 5.8.2
         version: 5.8.2
       web-test-runner-jasmine:
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.1.1
+        version: 0.1.1
 
 packages:
 
@@ -1984,8 +1984,8 @@ packages:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
 
-  web-test-runner-jasmine@0.1.0:
-    resolution: {integrity: sha512-eJWbxQl7A/dzDlKsdDZdyXCHMo0SWRjkYIpJMvPm6OKqOS83GD7S+M+V5+OE26zra0gDr+bDlO69pfearSbJ+A==}
+  web-test-runner-jasmine@0.1.1:
+    resolution: {integrity: sha512-KmVBJiJTExFKwfdrHluU0W/Kr7b0alW0c1NlO9/e6QivxIgL6bgMuCYJlCrqmntHCk+Vod/jusuKEplwMdQKnQ==}
     engines: {node: ^22.11.0}
 
   webdriver-js-extender@2.1.0:
@@ -2443,7 +2443,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@web/test-runner-chrome@0.18.0(patch_hash=sdcmdruhfajls5fgcrmywzbtte)':
+  '@web/test-runner-chrome@0.18.0(patch_hash=9b04fa08ff126a3b83bd1a253f6f70e851f0414497a709fee0ac57f1aeb3f67d)':
     dependencies:
       '@web/test-runner-core': 0.13.4
       '@web/test-runner-coverage-v8': 0.8.0
@@ -2520,7 +2520,7 @@ snapshots:
 
   '@web/test-runner-puppeteer@0.18.0(typescript@5.8.2)':
     dependencies:
-      '@web/test-runner-chrome': 0.18.0(patch_hash=sdcmdruhfajls5fgcrmywzbtte)
+      '@web/test-runner-chrome': 0.18.0(patch_hash=9b04fa08ff126a3b83bd1a253f6f70e851f0414497a709fee0ac57f1aeb3f67d)
       '@web/test-runner-core': 0.13.4
       puppeteer: 24.6.1(typescript@5.8.2)
     transitivePeerDependencies:
@@ -2559,7 +2559,7 @@ snapshots:
       '@web/browser-logs': 0.4.1
       '@web/config-loader': 0.3.3
       '@web/dev-server': 0.4.6
-      '@web/test-runner-chrome': 0.18.0(patch_hash=sdcmdruhfajls5fgcrmywzbtte)
+      '@web/test-runner-chrome': 0.18.0(patch_hash=9b04fa08ff126a3b83bd1a253f6f70e851f0414497a709fee0ac57f1aeb3f67d)
       '@web/test-runner-commands': 0.9.0
       '@web/test-runner-core': 0.13.4
       '@web/test-runner-mocha': 0.9.0
@@ -4174,7 +4174,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  web-test-runner-jasmine@0.1.0:
+  web-test-runner-jasmine@0.1.1:
     dependencies:
       '@web/test-runner': 0.19.0
       '@web/test-runner-core': 0.13.4


### PR DESCRIPTION
Updates `jasmine-web-test-runner` to 0.1.1 in order to include https://github.com/blueprintui/web-test-runner-jasmine/pull/15.