### PR TITLE
Upgrade runner-jasmine to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "protractor": "^7.0.0",
     "tinyglobby": "^0.2.12",
     "typescript": "5.8.2",
-    "web-test-runner-jasmine": "0.1.3"
+    "web-test-runner-jasmine": "0.1.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: 5.8.2
         version: 5.8.2
       web-test-runner-jasmine:
-        specifier: 0.1.3
-        version: 0.1.3(jasmine-core@5.8.0)(jasmine@5.8.0)
+        specifier: 0.1.4
+        version: 0.1.4(jasmine-core@5.8.0)(jasmine@5.8.0)
 
 packages:
 
@@ -1987,9 +1987,9 @@ packages:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
 
-  web-test-runner-jasmine@0.1.3:
-    resolution: {integrity: sha512-9BugvKD5JHX7+H8XpHyrUNjxOfL+wfoBJze9yT7e5s1JxERzpKvfbXBbPP0Ra/c6X2pBvq5mTgKcoXWJ1RK7Ag==}
-    engines: {node: 22.15.1}
+  web-test-runner-jasmine@0.1.4:
+    resolution: {integrity: sha512-SVR+SiacD7UuHrr5PwvZ+mDmDT940vuURK44XJS5WEqBdjZMdrmkgJQOyQgPbK2IKQi/eODKCBJ6rTkTKLIeCA==}
+    engines: {node: ^22.15.1}
     peerDependencies:
       jasmine: ^5.8.0
       jasmine-core: ^5.8.0
@@ -4181,7 +4181,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  web-test-runner-jasmine@0.1.3(jasmine-core@5.8.0)(jasmine@5.8.0):
+  web-test-runner-jasmine@0.1.4(jasmine-core@5.8.0)(jasmine@5.8.0):
     dependencies:
       '@web/test-runner': 0.20.2
       '@web/test-runner-core': 0.13.4


### PR DESCRIPTION
Provides compatibility with newer node versions. Version 0.1.3 has a bug where the engine in `package.json` is specified exactly, which was not intentional.