### PR TITLE
Deconflict npm_typescript repo name

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,6 +54,11 @@ bazel_dep(name = "aspect_rules_ts", version = "3.6.3")
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
 rules_ts_ext.deps(
+    # Specify a name manually to prevent conflicts in consumers that also use
+    # `aspect_rules_ts`. This requires that we override the default for `tsc`,
+    # `tsc_worker` and `validator` on all `ts_project` targets.
+    # Upstream issue: https://github.com/aspect-build/rules_ts/issues/843
+    name = "npm_rules_browsers_typescript",
     ts_version_from = "//:package.json",
 )
-use_repo(rules_ts_ext, "npm_typescript")
+use_repo(rules_ts_ext, "npm_rules_browsers_typescript")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -451,14 +451,14 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "aVqwKoRPrSXO367SJABlye04kmpR/9VM2xiXB3nh3Ls=",
-        "usagesDigest": "AhOAFe9uiw8di0gsfInIbSlRUsK6EjGLiJzelQLq3XA=",
+        "usagesDigest": "QgCJJqzfzt67YhcDRQ4LQ7mvPBhmWYFwo9v/cHAmVjw=",
         "recordedFileInputs": {
-          "@@//package.json": "4c5dc8f5b82ef14aa43a28bf41747618c8b82067554f1e497920805174b56b13"
+          "@@//package.json": "24fae2e64bcc44f0d8ab07473932c82f5bc05f12dad1431965dd027afe3730ec"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "npm_typescript": {
+          "npm_rules_browsers_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
               "bzlmod": true,

--- a/browsers/private/update-tool/BUILD.bazel
+++ b/browsers/private/update-tool/BUILD.bazel
@@ -4,7 +4,10 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 ts_project(
     name = "update_tool_lib",
     srcs = glob(["**/*.mts"]),
+    tsc = "@npm_rules_browsers_typescript//:tsc",
+    tsc_worker = "@npm_rules_browsers_typescript//:tsc_worker",
     tsconfig = "tsconfig.json",
+    validator = "@npm_rules_browsers_typescript//:validator",
     deps = [
         "//:node_modules/@puppeteer/browsers",
         "//:node_modules/@types/node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rules_browsers",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/protractor_test/BUILD.bazel
+++ b/protractor_test/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//visibility:public"])
 ts_project(
     name = "config",
     srcs = ["config.cts"],
+    tsc = "@npm_rules_browsers_typescript//:tsc",
+    tsc_worker = "@npm_rules_browsers_typescript//:tsc_worker",
     tsconfig = "tsconfig.json",
+    validator = "@npm_rules_browsers_typescript//:validator",
     deps = [
         "//:node_modules/@types/node",
         "//:node_modules/protractor",

--- a/server_test/BUILD.bazel
+++ b/server_test/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//visibility:public"])
 ts_project(
     name = "lib",
     srcs = ["test-runner.mts"],
+    tsc = "@npm_rules_browsers_typescript//:tsc",
+    tsc_worker = "@npm_rules_browsers_typescript//:tsc_worker",
     tsconfig = "tsconfig.json",
+    validator = "@npm_rules_browsers_typescript//:validator",
     deps = [
         "//:node_modules/@types/node",
         "//:node_modules/get-port",

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -14,4 +14,4 @@ use_repo(npm, "npm_rules_browsers")
 bazel_dep(name = "aspect_rules_ts", version = "3.6.3")
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
-use_repo(rules_ts_ext, "npm_typescript")
+use_repo(rules_ts_ext, "npm_rules_browsers_typescript")

--- a/test/MODULE.bazel.lock
+++ b/test/MODULE.bazel.lock
@@ -163,14 +163,14 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "aVqwKoRPrSXO367SJABlye04kmpR/9VM2xiXB3nh3Ls=",
-        "usagesDigest": "lk3gYQz5godZbL2xuLHDMLxwmNK8nHmKBQ4g4Q0Z/+g=",
+        "usagesDigest": "oa0AkIQUt6HMa8dLIiRs1EnoAbtoAnoESdw5pci0lC0=",
         "recordedFileInputs": {
-          "@@rules_browsers+//package.json": "4c5dc8f5b82ef14aa43a28bf41747618c8b82067554f1e497920805174b56b13"
+          "@@rules_browsers+//package.json": "24fae2e64bcc44f0d8ab07473932c82f5bc05f12dad1431965dd027afe3730ec"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "npm_typescript": {
+          "npm_rules_browsers_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
               "bzlmod": true,

--- a/test/wtr/typescript-multiple-files-should-fail/BUILD.bazel
+++ b/test/wtr/typescript-multiple-files-should-fail/BUILD.bazel
@@ -4,7 +4,10 @@ load("@rules_browsers//wtr:index.bzl", "wtr_test")
 ts_project(
     name = "test_lib",
     srcs = glob(["**/*.mts"]),
+    tsc = "@npm_rules_browsers_typescript//:tsc",
+    tsc_worker = "@npm_rules_browsers_typescript//:tsc_worker",
     tsconfig = "tsconfig.json",
+    validator = "@npm_rules_browsers_typescript//:validator",
     deps = ["//:node_modules/@types/jasmine"],
 )
 

--- a/test/wtr/typescript-multiple-files/BUILD.bazel
+++ b/test/wtr/typescript-multiple-files/BUILD.bazel
@@ -4,7 +4,10 @@ load("@rules_browsers//wtr:index.bzl", "wtr_test")
 ts_project(
     name = "test_lib",
     srcs = glob(["**/*.mts"]),
+    tsc = "@npm_rules_browsers_typescript//:tsc",
+    tsc_worker = "@npm_rules_browsers_typescript//:tsc_worker",
     tsconfig = "tsconfig.json",
+    validator = "@npm_rules_browsers_typescript//:validator",
     deps = ["//:node_modules/@types/jasmine"],
 )
 

--- a/test/wtr/typescript/BUILD.bazel
+++ b/test/wtr/typescript/BUILD.bazel
@@ -4,7 +4,10 @@ load("@rules_browsers//wtr:index.bzl", "wtr_test")
 ts_project(
     name = "test_lib",
     srcs = ["test.spec.mts"],
+    tsc = "@npm_rules_browsers_typescript//:tsc",
+    tsc_worker = "@npm_rules_browsers_typescript//:tsc_worker",
     tsconfig = "tsconfig.json",
+    validator = "@npm_rules_browsers_typescript//:validator",
     deps = ["//:node_modules/@types/jasmine"],
 )
 


### PR DESCRIPTION
Override the default repository name of `aspect_rules_ts`. The setup of `aspect_rules_ts` causes issues when using the default repository name in multiple modules in a dependency tree. This is annoying for consumers using this module and `aspect_rules_ts`.

The `ts_project` rule implicitly relies on the default repository name through defaults on its attributes. We have to manually override them on every use of `ts_project` to prevent errors.

Upstream issue for this annoyance: https://github.com/aspect-build/rules_ts/issues/843