### PR TITLE
Remove duplicate node_modules from protractor_test.

### DIFF
--- a/protractor_test/index.bzl
+++ b/protractor_test/index.bzl
@@ -16,11 +16,6 @@ def protractor_test(name, server, deps, extra_config = {}, data = [], enable_per
             ":%s_protractor_extra_config" % name,
             "@rules_browsers//browsers/chromium",
             "@rules_browsers//protractor_test:config",
-            # Depend on both the node modules from the calling module and the one's from the
-            # macro-defining module (rules_browsers). Without these, running Protractor tests fails
-            # when using Bzlmod.
-            "//:node_modules/protractor",
-            "//:node_modules/tinyglobby",
             Label("//:node_modules/protractor"),
             Label("//:node_modules/tinyglobby"),
         ],

--- a/test/protractor_test/BUILD.bazel
+++ b/test/protractor_test/BUILD.bazel
@@ -14,5 +14,14 @@ js_library(
 protractor_test(
     name = "test",
     server = ":server_bin",
-    deps = [":tests"],
+    deps = [
+        ":tests",
+        # Need to add these manually because the `Label` references in the `protractor_test`
+        # implementation mean it uses `rules_browsers` local node modules. These end up in a
+        # directory in `external/` under the execroot (because they're in a module). Since module
+        # resolution in Node looks for a `node_modules` directory in the ancestors, any
+        # `node_modules` in a subdirectory of the execroot won't be found.
+        "//:node_modules/protractor",
+        "//:node_modules/tinyglobby",
+    ],
 )


### PR DESCRIPTION
These cause issues when not using Bzlmod. Sadly, we do need module local modules when using Bzlmod, so the test module specifies them manually now.